### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">✅ To Go List CLI</h1>
 
-<img src="https://github.com/Dedo-Finger2/togo-cli/blob/refactor/public/images/cover.png?raw=true" />
+<img src="https://github.com/Dedo-Finger2/togo-cli/blob/master/public/images/cover.png?raw=true" />
 
 <p>
   <img src="https://img.shields.io/badge/--00ADD8?logo=go&logoColor=ffffff" />


### PR DESCRIPTION
Fixes the cover image not showing in the readme file. The cause of it was that after the branch renaming from refactor to master the image link, that was aiming for the refactor branch, didn't update. So we must update it manually in the readme file to look for the image in the new master branch.